### PR TITLE
Reverted to PHPUnit 4 (v5 not compatible with Laravel 5) + Switched to TwigBridge latest.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,13 +30,13 @@
         "laravel/framework": "~5.1",
         "laravel/socialite": "~2.0",
         "predis/predis": "~1.0",
-        "rcrowe/twigbridge": "0.8.1"
+        "rcrowe/twigbridge": "~0.9"
     },
     "require-dev": {
         "doctrine/dbal": "~2.5",
         "fzaninotto/faker": "~1.5",
         "phpspec/phpspec": "~2.1",
-        "phpunit/phpunit": "~5",
+        "phpunit/phpunit": "~4",
         "sauce/sausage": ">=0.17"
     },
     "autoload": {


### PR DESCRIPTION
Reverted to PHPUnit 4 (v5 not compatible with Laravel 5) + Switched to TwigBridge latest.