### PR TITLE
CI upgrade for Docker and Docker Compose

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ cache:
     - ./public/bower_components
 
 before_install:
-  - curl -L https://github.com/docker/compose/releases/download/1.4.0/docker-compose-`uname -s`-`uname -m` > docker-compose; chmod +x docker-compose; true
+  - curl -L https://github.com/docker/compose/releases/download/1.5.2/docker-compose-`uname -s`-`uname -m` > docker-compose; chmod +x docker-compose; true
   - sudo mv docker-compose /usr/local/bin/
   - pwd && docker -v && docker info && docker-compose -v
 

--- a/circle.yml
+++ b/circle.yml
@@ -1,7 +1,7 @@
 machine:
   pre:
-    - sudo curl -L -o /usr/bin/docker https://s3-external-1.amazonaws.com/circle-downloads/docker-1.8.2-circleci; sudo chmod 0755 /usr/bin/docker
-    - curl -L https://github.com/docker/compose/releases/download/1.4.2/docker-compose-`uname -s`-`uname -m` > docker-compose; sudo mv docker-compose /usr/bin/docker-compose; sudo chmod 0755 /usr/bin/docker-compose
+    - sudo curl -L -o /usr/bin/docker https://s3-external-1.amazonaws.com/circle-downloads/docker-1.9.1-circleci; sudo chmod 0755 /usr/bin/docker
+    - curl -L https://github.com/docker/compose/releases/download/1.5.2/docker-compose-`uname -s`-`uname -m` > docker-compose; sudo mv docker-compose /usr/bin/docker-compose; sudo chmod 0755 /usr/bin/docker-compose
   services:
     - docker
 

--- a/storage/build/scripts/hhvm/Dockerfile
+++ b/storage/build/scripts/hhvm/Dockerfile
@@ -76,8 +76,8 @@ RUN set -ex \
     gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
   done
 ENV NPM_CONFIG_LOGLEVEL info
-ENV NODE_VERSION 5.1.0
-ENV NPM_VERSION 3.4.1
+ENV NODE_VERSION 5.2.0
+ENV NPM_VERSION 3.5.1
 RUN curl -SLO "http://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.gz" \
     && curl -SLO "http://nodejs.org/dist/v$NODE_VERSION/SHASUMS256.txt.asc" \
     && gpg --verify SHASUMS256.txt.asc \

--- a/storage/build/scripts/php_5.6/Dockerfile
+++ b/storage/build/scripts/php_5.6/Dockerfile
@@ -68,8 +68,8 @@ RUN set -ex \
     gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
   done
 ENV NPM_CONFIG_LOGLEVEL info
-ENV NODE_VERSION 5.1.0
-ENV NPM_VERSION 3.4.1
+ENV NODE_VERSION 5.2.0
+ENV NPM_VERSION 3.5.1
 RUN curl -SLO "http://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.gz" \
     && curl -SLO "http://nodejs.org/dist/v$NODE_VERSION/SHASUMS256.txt.asc" \
     && gpg --verify SHASUMS256.txt.asc \


### PR DESCRIPTION
Upgraded CI to Docker 1.9.1 (for CircleCI only) and Docker Compose 1.5.2.